### PR TITLE
Make links in QA code sections more readable

### DIFF
--- a/styles/qa.css
+++ b/styles/qa.css
@@ -46,4 +46,17 @@ tbody td a {
   color: #000000 !important;
 }
 
+dl a,
+dl a:link,
+dl a:visited {
+  color: #6baae8;
+  text-decoration: none;
+  border: 0;
+}
+
+dl a:hover {
+  color: #693;
+  text-decoration: underline;
+}
+
 /* vim: set expandtab shiftwidth=2 softtabstop=2 tabstop=2 fdm=marker : */


### PR DESCRIPTION
This patch changes some colors for links used inside the dl elements at https://qa.php.net/phpt_details.php

## Before

![before](https://user-images.githubusercontent.com/1614009/47172434-bf287200-d30b-11e8-82a4-0ed2c74ab26b.png)

## After
![after](https://user-images.githubusercontent.com/1614009/47172441-c780ad00-d30b-11e8-92bd-c412980369f9.png)
